### PR TITLE
#22445 Added lock mechanism to NinjectWebApiHttpApplicationPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.3.2-mintra] - 2023-12-12
 
 ### Fixed
-- NinjectWebApiHttpApplication plugin can no longer be started multiple times on the same kernel.
+- `NinjectWebApiHttpApplication` plugin will no longer bind `DefaultFilterProviders` and `DefaultModelValidatorProviders` multiple times.
 
 ## [3.3.1] - 2020-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.3.2-mintra] - 2023-12-12
+
+### Fixed
+- NinjectWebApiHttpApplication plugin can no longer be started multiple times on the same kernel.
+
 ## [3.3.1] - 2020-02-08
 
 ### Changed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,9 +33,9 @@ build:
 artifacts:
   - path: 'src\**\*.nupkg'
 
-deploy:
-  provider: NuGet
-  api_key:
-    secure: ObZpjlJ2soInYT4Ooi+u2KeQQ1LRsBbRA9uPU7ctOma7CZxxNN8hPUVjwFUY2wS1
-  on:
-    appveyor_repo_tag: true
+# deploy:
+#   provider: NuGet
+#   api_key:
+#     secure: ObZpjlJ2soInYT4Ooi+u2KeQQ1LRsBbRA9uPU7ctOma7CZxxNN8hPUVjwFUY2wS1
+#   on:
+#     appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ init:
       }
       else
       {
-          Update-AppveyorBuild -Version "3.3.0-ci.$($env:APPVEYOR_BUILD_NUMBER)+sha.$($env:APPVEYOR_REPO_COMMIT.substring(0,7))"
+          Update-AppveyorBuild -Version "3.3.2-mintra+sha.$($env:APPVEYOR_REPO_COMMIT.substring(0,7))"
       }
 
 dotnet_csproj:


### PR DESCRIPTION
PR addresses following issue: [[22445]: OCS Service: Ninject throws exception on start-up when SOAP service is disabled](https://osl-srv-tfs.mintragroup.com/tfs/defaultcollection/OCS/_workitems/edit/22445)

`NinjectWebApiHttpApplicationPlugin` has been modified with the following properties being added:
- `initLock`: Lock used to prevent multiple threads accessing `Start()`.
- `initialized`: Used to store state of whether the plugin has been initialized.

Changelog has also been updated with new version and patch notes.